### PR TITLE
Fixed sequence opening connection and attaching link

### DIFF
--- a/iot/thermostat/src/main/java/io/enmasse/iot/controller/thermostat/Thermostat.java
+++ b/iot/thermostat/src/main/java/io/enmasse/iot/controller/thermostat/Thermostat.java
@@ -63,6 +63,7 @@ public class Thermostat extends AbstractVerticle {
             if (connection.succeeded()) {
                 log.info("Connected to {}:{}", messagingHost, messagingPort);
                 ProtonConnection connectionHandle = connection.result();
+                connectionHandle.open();
 
                 ProtonReceiver receiver = connectionHandle.createReceiver(notificationAddress);
                 receiver.handler(this::handleNotification);
@@ -75,7 +76,6 @@ public class Thermostat extends AbstractVerticle {
                     }
                 });
                 receiver.open();
-                connectionHandle.open();
                 this.connection = connectionHandle;
             } else {
                 log.info("Error connecting to {}:{}", messagingHost, messagingPort);


### PR DESCRIPTION
It's not a real issue because the underlying Proton library is able to send the OPEN frame and ATTACH frame in the correct order but it happened to me in the past as well and even if Proton fixes the order for us, Robbie suggested me to not do that ... and I trust Robbie :-)